### PR TITLE
Fetch PAT from Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# github-runner-autoscaler
+# GitHub Runner Autoscaler
+
+This project provides a Lambda function that launches ephemeral GitHub self-hosted
+runners on EC2 in response to GitHub workflow job events. The function is deployed
+using AWS SAM.
+
+## Secret configuration
+
+The function expects a GitHub personal access token (PAT) to be stored in AWS
+Secrets Manager. Create the secret before deploying:
+
+```bash
+aws secretsmanager create-secret --name my-github-pat --secret-string <PAT>
+```
+
+## Deployment
+
+Deploy the stack with SAM and provide the secret name and any additional runner
+labels as parameters:
+
+```bash
+sam deploy \
+  --parameter-overrides GitHubPATSecretName=my-github-pat \
+  --parameter-overrides ExtraRunnerLabels="gpu"
+```
+
+The `ExtraRunnerLabels` parameter is optional. When supplied, the labels are
+added to the default runner labels.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/aws/aws-lambda-go v1.46.0
 	github.com/aws/aws-sdk-go-v2 v1.26.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.9
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.152.0
+        github.com/aws/aws-sdk-go-v2/service/ec2 v1.152.0
+        github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.0
 	github.com/google/go-github/v60 v60.0.0
 )
 

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,15 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 
+Parameters:
+  GitHubPATSecretName:
+    Type: String
+    Description: Name of the Secrets Manager secret containing the GitHub PAT
+  ExtraRunnerLabels:
+    Type: String
+    Default: ""
+    Description: Additional comma separated labels for the runner
+
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
@@ -27,13 +36,15 @@ Resources:
                   Caching: false
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
-          PARAM1: VALUE
+          GITHUB_PAT_SECRET_NAME: !Ref GitHubPATSecretName
+          EXTRA_RUNNER_LABELS: !Ref ExtraRunnerLabels
       Policies:
         - Statement:
             - Sid: RunInstances
               Effect: Allow
               Action:
                 - ssm:GetParameters
+                - secretsmanager:GetSecretValue
                 - iam:PassRole
                 - ec2:CreateTags
                 - ec2:RunInstances


### PR DESCRIPTION
## Summary
- store GitHub PAT in AWS Secrets Manager
- allow extra runner labels via parameter
- document how to configure secrets and parameters for `sam deploy`

## Testing
- `gofmt -w main.go`
