### PR TITLE
Embed user data template

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main //nolint: revive
 
 import (
+	"bytes"
 	"context"
+	_ "embed"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -11,6 +13,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"text/template"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -21,6 +24,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/google/go-github/v60/github"
 )
+
+//go:embed user-data.sh
+var userData string
 
 func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	var githubEventHeader string
@@ -118,8 +124,15 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 
 		slog.Info("creating instance", "instanceType", instanceType)
 
-		finalUserData := strings.ReplaceAll(userData, "<GITHUB_PAT>", pat)
-		finalUserData = strings.ReplaceAll(finalUserData, "<EXTRA_LABELS>", extraLabels)
+		tpl, err := template.New("userdata").Parse(userData)
+		if err != nil {
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
+		}
+		var buf bytes.Buffer
+		if err := tpl.Execute(&buf, map[string]string{"GitHubPAT": pat, "ExtraLabels": extraLabels}); err != nil {
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
+		}
+		finalUserData := buf.String()
 
 		output, err := svc.RunInstances(
 			context.TODO(),
@@ -194,30 +207,3 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 func main() {
 	lambda.Start(handler)
 }
-
-var userData = `#!/bin/bash
-set -x
-START_TIME=$(date +%s)
-shutdown +60
-sed -i 's/ap-southeast-3/us-east-2/g' /etc/apt/sources.list
-usermod -aG docker ubuntu
-cd /opt
-mkdir actions-runner
-chown -R ubuntu:ubuntu actions-runner
-cd actions-runner
-sudo -u ubuntu tar xzf ../runner-cache/actions-runner-linux-* -C .
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-INSTANCE_TYPE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type)
-GITHUB_TOKEN=$(curl -L \
-  -X POST \
-  -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer <GITHUB_PAT>" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  https://api.github.com/orgs/frgrisk/actions/runners/registration-token | jq -r .token)
-sudo -u ubuntu ./config.sh --url https://github.com/frgrisk --token $GITHUB_TOKEN --disableupdate --ephemeral --labels $INSTANCE_TYPE,ephemeral,X64<EXTRA_LABELS> --unattended
-END_TIME=$(date +%s)
-EXECUTION_TIME=$((END_TIME - START_TIME))
-echo "Script execution time: $EXECUTION_TIME seconds" | tee -a /var/log/setup-time.log
-sudo -u ubuntu ./run.sh
-shutdown now
-`

--- a/main.go
+++ b/main.go
@@ -128,10 +128,12 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		if err != nil {
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
+
 		var buf bytes.Buffer
 		if err := tpl.Execute(&buf, map[string]string{"GitHubPAT": pat, "ExtraLabels": extraLabels}); err != nil {
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
+
 		finalUserData := buf.String()
 
 		output, err := svc.RunInstances(

--- a/user-data.sh
+++ b/user-data.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -x
+START_TIME=$(date +%s)
+shutdown +60
+sed -i 's/ap-southeast-3/us-east-2/g' /etc/apt/sources.list
+usermod -aG docker ubuntu
+cd /opt
+mkdir actions-runner
+chown -R ubuntu:ubuntu actions-runner
+cd actions-runner
+sudo -u ubuntu tar xzf ../runner-cache/actions-runner-linux-* -C .
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+INSTANCE_TYPE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type)
+GITHUB_TOKEN=$(curl -L \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer {{.GitHubPAT}}" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/orgs/frgrisk/actions/runners/registration-token | jq -r .token)
+sudo -u ubuntu ./config.sh --url https://github.com/frgrisk --token $GITHUB_TOKEN --disableupdate --ephemeral --labels $INSTANCE_TYPE,ephemeral,X64{{.ExtraLabels}} --unattended
+END_TIME=$(date +%s)
+EXECUTION_TIME=$((END_TIME - START_TIME))
+echo "Script execution time: $EXECUTION_TIME seconds" | tee -a /var/log/setup-time.log
+sudo -u ubuntu ./run.sh
+shutdown now


### PR DESCRIPTION
## Summary
- switch userdata to Go template embedded from `user-data.sh`
- fill the template at runtime instead of using string replacements

## Testing
- `go vet ./...`
