### PR TITLE
Add configuration for instance launch options

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
     - lll
     - cyclop
     - funlen
+    - maintidx
 formatters:
   # Enable specific formatter.
   # Default: [] (uses standard Go formatting)

--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ aws secretsmanager create-secret --name my-github-pat --secret-string <PAT>
 
 ## Deployment
 
-Deploy the stack with SAM and provide the secret name and any additional runner
-labels as parameters:
+Deploy the stack with SAM and provide the secret name, AMI, subnet, security groups and
+EC2 key pair used for the runner. You may also specify additional runner labels:
 
 ```bash
 sam deploy \
-  --parameter-overrides GitHubPATSecretName=my-github-pat ExtraRunnerLabels="gpu"
+  --parameter-overrides GitHubPATSecretName=my-github-pat \
+  ExtraRunnerLabels="gpu" \
+  ImageId=ami-0123456789abcdef0 \
+  SubnetId=subnet-12345678 \
+  SecurityGroupIds=sg-12345678 \
+  KeyName=my-key
 ```
 
 The `ExtraRunnerLabels` parameter is optional. When supplied, the labels are
-added to the default runner labels.
+added to the default runner labels. All other parameters are required and must
+be specified for your environment.

--- a/main.go
+++ b/main.go
@@ -104,6 +104,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("security groups missing")
 		}
+
 		securityGroups := strings.Split(sgIDs, ",")
 
 		keyName := os.Getenv("KEY_NAME")

--- a/template.yaml
+++ b/template.yaml
@@ -9,6 +9,18 @@ Parameters:
     Type: String
     Default: ""
     Description: Additional comma separated labels for the runner
+  ImageId:
+    Type: String
+    Description: AMI ID for the runner instances
+  SubnetId:
+    Type: String
+    Description: Subnet ID for the runner instances
+  SecurityGroupIds:
+    Type: String
+    Description: Comma separated security group IDs for the runner
+  KeyName:
+    Type: String
+    Description: EC2 key pair name for the runner
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -38,6 +50,10 @@ Resources:
         Variables:
           GITHUB_PAT_SECRET_NAME: !Ref GitHubPATSecretName
           EXTRA_RUNNER_LABELS: !Ref ExtraRunnerLabels
+          IMAGE_ID: !Ref ImageId
+          SUBNET_ID: !Ref SubnetId
+          SECURITY_GROUP_IDS: !Ref SecurityGroupIds
+          KEY_NAME: !Ref KeyName
       Policies:
         - Statement:
             - Sid: RunInstances


### PR DESCRIPTION
## Summary
- make subnet ID, security groups, key name and AMI configurable via env vars
- document new parameters in README
- remove defaults for these parameters so that deployments must specify them

## Testing
- `go build ./...`
