### PR TITLE
Add 14-day retention policy to CloudWatch log groups

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -60,6 +60,20 @@ Resources:
     Properties:
       Roles:
         - !Ref RunnerInstanceRole
+  
+  # CloudWatch Log Groups with retention
+  GitHubActionHookFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${GitHubActionHookFunction}'
+      RetentionInDays: 14
+  
+  EC2RunnerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: '/aws/ec2/github-runner'
+      RetentionInDays: 14
+  
   GitHubActionHookFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:


### PR DESCRIPTION
## Summary
- Add explicit CloudWatch log group definitions with 14-day retention
- Prevent indefinite log storage and reduce AWS costs

## Changes
- Added `GitHubActionHookFunctionLogGroup` resource for Lambda function logs
- Added `EC2RunnerLogGroup` resource for EC2 instance logs  
- Both log groups configured with `RetentionInDays: 14`

## Impact
This change will:
- Automatically expire logs older than 14 days
- Reduce CloudWatch Logs storage costs
- Maintain compliance with log retention best practices

The 14-day retention period provides sufficient time for debugging and troubleshooting while preventing unnecessary log accumulation.