### PR TITLE
Add warm pool support for faster runner startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/aws/aws-lambda-go v1.51.1
-	github.com/aws/aws-sdk-go-v2 v1.41.0
+	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.6
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.279.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
@@ -14,12 +14,13 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-lambda-go v1.51.1 h1:FpqpCK2WOSoq6hJvO9PhN44GzZHWCN3e9DUQgK0B
 github.com/aws/aws-lambda-go v1.51.1/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.41.0 h1:tNvqh1s+v0vFYdA1xq0aOJH+Y5cRyZ5upu6roPgPKd4=
 github.com/aws/aws-sdk-go-v2 v1.41.0/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
+github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
+github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/config v1.32.6 h1:hFLBGUKjmLAekvi1evLi5hVvFQtSo3GYwi+Bx4lpJf8=
 github.com/aws/aws-sdk-go-v2/config v1.32.6/go.mod h1:lcUL/gcd8WyjCrMnxez5OXkO3/rwcNmvfno62tnXNcI=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.6 h1:F9vWao2TwjV2MyiyVS+duza0NIRtAslgLUM0vTA1ZaE=
@@ -10,8 +12,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 h1:80+uETIWS1BqjnN9uJ0dBU
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16/go.mod h1:wOOsYuxYuB/7FlnVtzeBYRcjSRtQpAW0hCP7tIULMwo=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 h1:rgGwPzb82iBYSvHMHXc8h9mRoOUBZIGFgKb9qniaZZc=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16/go.mod h1:L/UxsGeKpGoIj6DxfhOWHWQ/kGKcd4I1VncE4++IyKA=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 h1:xOLELNKGp2vsiteLsvLPwxC+mYmO6OZ8PYgiuPJzF8U=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17/go.mod h1:5M5CI3D12dNOtH3/mk6minaRwI2/37ifCURZISxA/IQ=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 h1:1jtGzuV7c82xnqOVfx2F0xmJcOw5374L7N6juGW6x6U=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16/go.mod h1:M2E5OQf+XLe+SZGmmpaI2yy+J326aFf6/+54PoxSANc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 h1:WWLqlh79iO48yLkj1v3ISRNiv+3KdQoZ6JWyfcsyQik=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17/go.mod h1:EhG22vHRrvF8oXSTYStZhJc1aUgKtnJe+aOiFEV90cM=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.279.0 h1:o7eJKe6VYAnqERPlLAvDW5VKXV6eTKv1oxTpMoDP378=
@@ -24,6 +30,8 @@ github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0 h1:vL6rQXcGtFv9q/9eR
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0/go.mod h1:QwEDLD+7EukuEUnbWtiNE8LhgvvmhjZoi4XAppYPtyc=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.4 h1:HpI7aMmJ+mm1wkSHIA2t5EaFFv5EFYXePW30p1EIrbQ=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.4/go.mod h1:C5RdGMYGlfM0gYq/tifqgn4EbyX99V15P2V3R+VHbQU=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8 h1:31Llf5VfrZ78YvYs7sWcS7L2m3waikzRc6q1nYenVS4=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8/go.mod h1:/jgaDlU1UImoxTxhRNxXHvBAPqPZQ8oCjcPbbkR6kac=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.8 h1:aM/Q24rIlS3bRAhTyFurowU8A0SMyGDtEOY/l/s/1Uw=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.8/go.mod h1:+fWt2UHSb4kS7Pu8y+BMBvJF0EWx+4H0hzNwtDNRTrg=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 h1:AHDr0DaHIAo8c9t1emrzAlVDFp+iMMKnPdYy6XO4MCE=

--- a/main.go
+++ b/main.go
@@ -115,11 +115,11 @@ func startWarmInstance(ctx context.Context, svc *ec2.Client, instanceID string, 
 
 	// Update user data with the full setup script wrapped in multipart format
 	// so it runs on every boot (including this activation)
+	// Note: BlobAttributeValue handles base64 encoding automatically, don't pre-encode
 	wrappedUserData := wrapInMultipart(finalUserData)
-	encodedUserData := base64.StdEncoding.EncodeToString([]byte(wrappedUserData))
 	_, err = svc.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
 		InstanceId: aws.String(instanceID),
-		UserData:   &types.BlobAttributeValue{Value: []byte(encodedUserData)},
+		UserData:   &types.BlobAttributeValue{Value: []byte(wrappedUserData)},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update user data: %w", err)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -14,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -27,6 +29,323 @@ import (
 
 //go:embed user-data.sh
 var userData string
+
+// LaunchConfig holds common EC2 launch configuration.
+type LaunchConfig struct {
+	ImageID            string
+	SubnetID           string
+	SecurityGroups     []string
+	KeyName            string
+	InstanceProfileArn string
+}
+
+// parseWarmPoolConfig parses the WARM_POOL_CONFIG environment variable.
+// Returns a map of instance type to target pool size.
+func parseWarmPoolConfig() map[string]int {
+	configStr := os.Getenv("WARM_POOL_CONFIG")
+	if configStr == "" || configStr == "{}" {
+		return nil
+	}
+
+	var poolConfig map[string]int
+	if err := json.Unmarshal([]byte(configStr), &poolConfig); err != nil {
+		slog.Error("failed to parse WARM_POOL_CONFIG", "error", err.Error(), "config", configStr)
+		return nil
+	}
+
+	return poolConfig
+}
+
+// findAvailableWarmInstance searches for a stopped warm pool instance of the requested type.
+func findAvailableWarmInstance(ctx context.Context, svc *ec2.Client, instanceType types.InstanceType) (*string, error) {
+	output, err := svc.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("tag:WarmPool"),
+				Values: []string{"true"},
+			},
+			{
+				Name:   aws.String("tag:WarmPoolStatus"),
+				Values: []string{"available"},
+			},
+			{
+				Name:   aws.String("tag:WarmPoolInstanceType"),
+				Values: []string{string(instanceType)},
+			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{"stopped"},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe instances: %w", err)
+	}
+
+	for _, reservation := range output.Reservations {
+		for _, instance := range reservation.Instances {
+			return instance.InstanceId, nil
+		}
+	}
+
+	return nil, nil // No available instance found
+}
+
+// startWarmInstance activates a stopped warm pool instance for a job.
+// It sets the activation tag, updates user-data, changes shutdown behavior to TERMINATE, and starts the instance.
+func startWarmInstance(ctx context.Context, svc *ec2.Client, instanceID string, jobEventID int64, finalUserData string) error {
+	// Update tags to mark as activated and in-use
+	_, err := svc.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{instanceID},
+		Tags: []types.Tag{
+			{Key: aws.String("WarmPoolStatus"), Value: aws.String("in-use")},
+			{Key: aws.String("WarmPoolActivated"), Value: aws.String("true")},
+			{Key: aws.String("GitHub Workflow Job Event ID"), Value: aws.String(strconv.FormatInt(jobEventID, 10))},
+			{Key: aws.String("Name"), Value: aws.String("GitHub Workflow Ephemeral Runner")},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update tags: %w", err)
+	}
+
+	// Change shutdown behavior to TERMINATE so instance terminates after job
+	_, err = svc.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+		InstanceId: aws.String(instanceID),
+		InstanceInitiatedShutdownBehavior: &types.AttributeValue{
+			Value: aws.String("terminate"),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update shutdown behavior: %w", err)
+	}
+
+	// Update user data with the full setup script wrapped in multipart format
+	// so it runs on every boot (including this activation)
+	wrappedUserData := wrapInMultipart(finalUserData)
+	encodedUserData := base64.StdEncoding.EncodeToString([]byte(wrappedUserData))
+	_, err = svc.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+		InstanceId: aws.String(instanceID),
+		UserData:   &types.BlobAttributeValue{Value: []byte(encodedUserData)},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update user data: %w", err)
+	}
+
+	// Start the instance
+	startOutput, err := svc.StartInstances(ctx, &ec2.StartInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start instance: %w", err)
+	}
+
+	// Verify the instance was actually stopped before we started it
+	for _, change := range startOutput.StartingInstances {
+		if *change.InstanceId == instanceID {
+			if change.PreviousState.Name != types.InstanceStateNameStopped {
+				return fmt.Errorf("instance %s was not stopped (was %s)", instanceID, change.PreviousState.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// countWarmPoolInstances counts available instances in the warm pool for a given type.
+func countWarmPoolInstances(ctx context.Context, svc *ec2.Client, instanceType types.InstanceType) (int, error) {
+	output, err := svc.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("tag:WarmPool"),
+				Values: []string{"true"},
+			},
+			{
+				Name:   aws.String("tag:WarmPoolStatus"),
+				Values: []string{"available"},
+			},
+			{
+				Name:   aws.String("tag:WarmPoolInstanceType"),
+				Values: []string{string(instanceType)},
+			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{"stopped", "stopping"},
+			},
+		},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to describe instances: %w", err)
+	}
+
+	count := 0
+	for _, reservation := range output.Reservations {
+		count += len(reservation.Instances)
+	}
+
+	return count, nil
+}
+
+// warmPoolInitUserData is a minimal script that stops the instance on first boot.
+// Uses multipart MIME format with cloud-config to run scripts on every boot.
+const warmPoolInitUserData = `Content-Type: multipart/mixed; boundary="//"
+MIME-Version: 1.0
+
+--//
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config.txt"
+
+#cloud-config
+cloud_final_modules:
+- [scripts-user, always]
+
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="userdata.txt"
+
+#!/bin/bash
+# Warm pool init: just stop the instance after first boot
+# When activated, user-data will be replaced with the real setup script
+echo "Warm pool instance initializing, stopping to enter pool..."
+shutdown -h now
+--//--
+`
+
+// wrapInMultipart wraps a shell script in multipart MIME format that runs on every boot.
+func wrapInMultipart(script string) string {
+	return fmt.Sprintf(`Content-Type: multipart/mixed; boundary="//"
+MIME-Version: 1.0
+
+--//
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config.txt"
+
+#cloud-config
+cloud_final_modules:
+- [scripts-user, always]
+
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="userdata.txt"
+
+%s
+--//--
+`, script)
+}
+
+// launchWarmPoolInstance launches a new instance destined for the warm pool.
+// Instances will stop after first boot and terminate after being used for a job.
+func launchWarmPoolInstance(ctx context.Context, svc *ec2.Client, instanceType types.InstanceType, launchConfig LaunchConfig) (*string, error) {
+	tags := []types.Tag{
+		{Key: aws.String("WarmPool"), Value: aws.String("true")},
+		{Key: aws.String("WarmPoolStatus"), Value: aws.String("available")},
+		{Key: aws.String("WarmPoolActivated"), Value: aws.String("false")},
+		{Key: aws.String("WarmPoolInstanceType"), Value: aws.String(string(instanceType))},
+		{Key: aws.String("WarmPoolCreatedAt"), Value: aws.String(time.Now().UTC().Format(time.RFC3339))},
+		{Key: aws.String("Name"), Value: aws.String(fmt.Sprintf("GitHub Runner Warm Pool - %s", instanceType))},
+	}
+
+	output, err := svc.RunInstances(ctx, &ec2.RunInstancesInput{
+		MinCount:                          aws.Int32(1),
+		MaxCount:                          aws.Int32(1),
+		EbsOptimized:                      aws.Bool(true),
+		ImageId:                           aws.String(launchConfig.ImageID),
+		InstanceInitiatedShutdownBehavior: types.ShutdownBehaviorStop, // STOP on first boot to enter warm pool
+		InstanceType:                      instanceType,
+		IamInstanceProfile: &types.IamInstanceProfileSpecification{
+			Arn: aws.String(launchConfig.InstanceProfileArn),
+		},
+		NetworkInterfaces: []types.InstanceNetworkInterfaceSpecification{
+			{
+				AssociatePublicIpAddress: aws.Bool(true),
+				SubnetId:                 aws.String(launchConfig.SubnetID),
+				DeleteOnTermination:      aws.Bool(true),
+				DeviceIndex:              aws.Int32(0),
+				Groups:                   launchConfig.SecurityGroups,
+			},
+		},
+		KeyName:    aws.String(launchConfig.KeyName),
+		Monitoring: &types.RunInstancesMonitoringEnabled{Enabled: aws.Bool(true)},
+		TagSpecifications: []types.TagSpecification{
+			{ResourceType: types.ResourceTypeInstance, Tags: tags},
+			{ResourceType: types.ResourceTypeVolume, Tags: tags},
+		},
+		UserData: aws.String(base64.StdEncoding.EncodeToString([]byte(warmPoolInitUserData))),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to launch warm pool instance: %w", err)
+	}
+
+	if len(output.Instances) == 0 {
+		return nil, errors.New("no instance created")
+	}
+
+	return output.Instances[0].InstanceId, nil
+}
+
+// launchFreshInstance launches a new instance that terminates after use (current behavior).
+func launchFreshInstance(ctx context.Context, svc *ec2.Client, instanceType types.InstanceType, launchConfig LaunchConfig, finalUserData string, jobEventID int64) (*string, error) {
+	tags := []types.Tag{
+		{
+			Key:   aws.String("GitHub Workflow Job Event ID"),
+			Value: aws.String(strconv.FormatInt(jobEventID, 10)),
+		},
+		{
+			Key:   aws.String("Name"),
+			Value: aws.String("GitHub Workflow Ephemeral Runner"),
+		},
+	}
+
+	output, err := svc.RunInstances(ctx, &ec2.RunInstancesInput{
+		MinCount:                          aws.Int32(1),
+		MaxCount:                          aws.Int32(1),
+		EbsOptimized:                      aws.Bool(true),
+		ImageId:                           aws.String(launchConfig.ImageID),
+		InstanceInitiatedShutdownBehavior: types.ShutdownBehaviorTerminate,
+		InstanceType:                      instanceType,
+		IamInstanceProfile: &types.IamInstanceProfileSpecification{
+			Arn: aws.String(launchConfig.InstanceProfileArn),
+		},
+		NetworkInterfaces: []types.InstanceNetworkInterfaceSpecification{
+			{
+				AssociatePublicIpAddress: aws.Bool(true),
+				SubnetId:                 aws.String(launchConfig.SubnetID),
+				DeleteOnTermination:      aws.Bool(true),
+				DeviceIndex:              aws.Int32(0),
+				Groups:                   launchConfig.SecurityGroups,
+			},
+		},
+		KeyName:    aws.String(launchConfig.KeyName),
+		Monitoring: &types.RunInstancesMonitoringEnabled{Enabled: aws.Bool(true)},
+		TagSpecifications: []types.TagSpecification{
+			{
+				ResourceType: types.ResourceTypeInstance,
+				Tags:         tags,
+			},
+			{
+				ResourceType: types.ResourceTypeVolume,
+				Tags:         tags,
+			},
+		},
+		UserData: aws.String(base64.StdEncoding.EncodeToString([]byte(finalUserData))),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to launch instance: %w", err)
+	}
+
+	if len(output.Instances) == 0 {
+		return nil, errors.New("no instance created")
+	}
+
+	return output.Instances[0].InstanceId, nil
+}
 
 func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	var githubEventHeader string
@@ -62,7 +381,9 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusOK}, nil
 		}
 
-		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-2"))
+		ctx := context.TODO()
+
+		cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-east-2"))
 		if err != nil {
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
@@ -77,7 +398,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("secret name missing")
 		}
 
-		secretOut, err := sm.GetSecretValue(context.TODO(), &secretsmanager.GetSecretValueInput{SecretId: aws.String(secretName)})
+		secretOut, err := sm.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{SecretId: aws.String(secretName)})
 		if err != nil {
 			slog.Error("failed to get secret", "secret", secretName, "error", err.Error())
 
@@ -128,15 +449,12 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("image id missing")
 		}
 
-		tags := []types.Tag{
-			{
-				Key:   aws.String("GitHub Workflow Job Event ID"),
-				Value: aws.String(strconv.Itoa(int(event.GetWorkflowJob().GetID()))),
-			},
-			{
-				Key:   aws.String("Name"),
-				Value: aws.String("GitHub Workflow Ephemeral Runner"),
-			},
+		launchConfig := LaunchConfig{
+			ImageID:            imageID,
+			SubnetID:           subnetID,
+			SecurityGroups:     securityGroups,
+			KeyName:            keyName,
+			InstanceProfileArn: instanceProfileArn,
 		}
 
 		ephemeral := slices.Contains(event.GetWorkflowJob().Labels, "ephemeral")
@@ -159,7 +477,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			}
 		}
 
-		slog.Info("creating instance", "instanceType", instanceType)
+		slog.Info("processing job", "instanceType", instanceType, "jobID", event.GetWorkflowJob().GetID())
 
 		tpl, err := template.New("userdata").Parse(userData)
 		if err != nil {
@@ -172,66 +490,96 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		}
 
 		finalUserData := buf.String()
+		jobEventID := event.GetWorkflowJob().GetID()
 
-		output, err := svc.RunInstances(
-			context.TODO(),
-			&ec2.RunInstancesInput{
-				MinCount:                          aws.Int32(1),
-				MaxCount:                          aws.Int32(1),
-				EbsOptimized:                      aws.Bool(true),
-				ImageId:                           aws.String(imageID),
-				InstanceInitiatedShutdownBehavior: types.ShutdownBehaviorTerminate,
-				InstanceType:                      instanceType,
-				IamInstanceProfile: &types.IamInstanceProfileSpecification{
-					Arn: aws.String(instanceProfileArn),
-				},
-				NetworkInterfaces: []types.InstanceNetworkInterfaceSpecification{
-					{
-						AssociatePublicIpAddress: aws.Bool(true),
-						SubnetId:                 aws.String(subnetID),
-						DeleteOnTermination:      aws.Bool(true),
-						DeviceIndex:              aws.Int32(0),
-						Groups:                   securityGroups,
-					},
-				},
-				KeyName:    aws.String(keyName),
-				Monitoring: &types.RunInstancesMonitoringEnabled{Enabled: aws.Bool(true)},
-				TagSpecifications: []types.TagSpecification{
-					{
-						ResourceType: types.ResourceTypeInstance,
-						Tags:         tags,
-					},
-					{
-						ResourceType: types.ResourceTypeVolume,
-						Tags:         tags,
-					},
-				},
-				// base64 encode user data
-				UserData: aws.String(base64.StdEncoding.EncodeToString([]byte(finalUserData))),
-			},
-		)
-		if err != nil {
-			slog.Error(err.Error())
-
-			return events.APIGatewayProxyResponse{
-				Body:       err.Error(),
-				StatusCode: http.StatusInternalServerError,
-			}, err
+		// Parse warm pool configuration
+		poolConfig := parseWarmPoolConfig()
+		targetSize := 0
+		if poolConfig != nil {
+			targetSize = poolConfig[string(instanceType)]
 		}
 
-		if len(output.Instances) == 0 {
-			slog.Error("no instance created")
+		var instanceID *string
 
-			return events.APIGatewayProxyResponse{
-				Body:       "no instance created",
-				StatusCode: http.StatusInternalServerError,
-			}, nil
+		// Try warm pool if configured for this instance type
+		if targetSize > 0 {
+			slog.Info("checking warm pool", "instanceType", instanceType, "targetSize", targetSize)
+
+			warmInstanceID, err := findAvailableWarmInstance(ctx, svc, instanceType)
+			if err != nil {
+				slog.Warn("failed to query warm pool", "error", err.Error())
+				// Fall through to fresh launch
+			} else if warmInstanceID != nil {
+				slog.Info("found warm pool instance", "instanceID", *warmInstanceID)
+
+				err = startWarmInstance(ctx, svc, *warmInstanceID, jobEventID, finalUserData)
+				if err != nil {
+					slog.Error("failed to start warm instance", "instanceID", *warmInstanceID, "error", err.Error())
+					// Mark instance for cleanup and fall through to fresh launch
+					_, _ = svc.CreateTags(ctx, &ec2.CreateTagsInput{
+						Resources: []string{*warmInstanceID},
+						Tags: []types.Tag{
+							{Key: aws.String("WarmPoolStatus"), Value: aws.String("failed")},
+						},
+					})
+				} else {
+					instanceID = warmInstanceID
+					slog.Info("started warm pool instance", "instanceID", *instanceID)
+				}
+			} else {
+				slog.Info("no warm pool instance available", "instanceType", instanceType)
+			}
 		}
 
-		slog.Info("instance created", "instanceID", output.Instances[0].InstanceId)
+		// Fallback: launch fresh instance if no warm pool instance was used
+		if instanceID == nil {
+			slog.Info("launching fresh instance", "instanceType", instanceType)
+
+			if targetSize > 0 {
+				// Warm pool is configured but no instance available - launch fresh instance that terminates
+				// (Don't create a warm pool instance that will stop - we need it now)
+				instanceID, err = launchFreshInstance(ctx, svc, instanceType, launchConfig, finalUserData, jobEventID)
+				if err != nil {
+					slog.Error("failed to launch fresh instance", "error", err.Error())
+					return events.APIGatewayProxyResponse{
+						Body:       err.Error(),
+						StatusCode: http.StatusInternalServerError,
+					}, err
+				}
+			} else {
+				// No warm pool configured - launch regular instance that terminates
+				instanceID, err = launchFreshInstance(ctx, svc, instanceType, launchConfig, finalUserData, jobEventID)
+				if err != nil {
+					slog.Error("failed to launch fresh instance", "error", err.Error())
+					return events.APIGatewayProxyResponse{
+						Body:       err.Error(),
+						StatusCode: http.StatusInternalServerError,
+					}, err
+				}
+			}
+
+			slog.Info("instance launched", "instanceID", *instanceID)
+		}
+
+		// Replenish warm pool if we used a warm instance (or if pool is under target)
+		if targetSize > 0 {
+			currentCount, err := countWarmPoolInstances(ctx, svc, instanceType)
+			if err != nil {
+				slog.Warn("failed to count warm pool", "error", err.Error())
+			} else if currentCount < targetSize {
+				slog.Info("replenishing warm pool", "instanceType", instanceType, "current", currentCount, "target", targetSize)
+
+				newID, err := launchWarmPoolInstance(ctx, svc, instanceType, launchConfig)
+				if err != nil {
+					slog.Warn("failed to launch warm pool replacement", "error", err.Error())
+				} else {
+					slog.Info("launched warm pool replacement", "instanceID", *newID)
+				}
+			}
+		}
 
 		return events.APIGatewayProxyResponse{
-			Body:       *output.Instances[0].InstanceId,
+			Body:       *instanceID,
 			StatusCode: http.StatusOK,
 		}, nil
 

--- a/template.yaml
+++ b/template.yaml
@@ -60,6 +60,15 @@ Resources:
                   - logs:PutLogEvents
                   - logs:DescribeLogStreams
                 Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/ec2/github-runner:*'
+        - PolicyName: SSMJITConfigPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:DeleteParameter
+                Resource: !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/github-runner/jit-config/*'
 
   RunnerInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -123,6 +132,12 @@ Resources:
               Action:
                 - secretsmanager:GetSecretValue
               Resource: !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${GitHubPATSecretName}*
+            - Sid: SSMJITConfig
+              Effect: Allow
+              Action:
+                - ssm:PutParameter
+                - ssm:DeleteParameter
+              Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/github-runner/jit-config/*
     Metadata:
       BuildMethod: makefile
 

--- a/template.yaml
+++ b/template.yaml
@@ -83,6 +83,13 @@ Resources:
               - method.request.header.X-GitHub-Event:
                   Required: true
                   Caching: false
+        WarmPoolMaintenance:
+          Type: Schedule
+          Properties:
+            Schedule: rate(5 minutes)
+            Description: Maintain warm pool of EC2 instances
+            Enabled: true
+            Input: '{"source": "warmPoolMaintenance"}'
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           GITHUB_PAT_SECRET_NAME: !Ref GitHubPATSecretName

--- a/template.yaml
+++ b/template.yaml
@@ -21,11 +21,17 @@ Parameters:
   KeyName:
     Type: String
     Description: EC2 key pair name for the runner
+  WarmPoolConfig:
+    Type: String
+    Default: "{}"
+    Description: >
+      JSON map of instance type to pool size. Empty {} disables warm pool.
+      Example: {"c8a.2xlarge":2,"c8a.4xlarge":1}
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 5
+    Timeout: 30
     MemorySize: 128
 
 Resources:
@@ -86,6 +92,7 @@ Resources:
           SECURITY_GROUP_IDS: !Ref SecurityGroupIds
           KEY_NAME: !Ref KeyName
           INSTANCE_PROFILE_ARN: !GetAtt RunnerInstanceProfile.Arn
+          WARM_POOL_CONFIG: !Ref WarmPoolConfig
       Policies:
         - Statement:
             - Sid: RunInstances
@@ -95,6 +102,14 @@ Resources:
                 - iam:PassRole
                 - ec2:CreateTags
                 - ec2:RunInstances
+              Resource: "*"
+            - Sid: WarmPoolManagement
+              Effect: Allow
+              Action:
+                - ec2:DescribeInstances
+                - ec2:StartInstances
+                - ec2:StopInstances
+                - ec2:ModifyInstanceAttribute
               Resource: "*"
             - Sid: GetGitHubPAT
               Effect: Allow

--- a/user-data.sh
+++ b/user-data.sh
@@ -57,19 +57,16 @@ sed -i 's/ap-southeast-3/us-east-2/g' /etc/apt/sources.list
 # Add ubuntu user to docker group
 usermod -aG docker ubuntu
 
-# Setup runner directory
-cd /opt
-mkdir -p actions-runner
-chown -R ubuntu:ubuntu actions-runner
-cd actions-runner
+# Use pre-extracted runner directory
+cd /opt/actions-runner
 
-# Extract runner
-log_to_cloudwatch "INFO" "Extracting GitHub runner"
-if ! sudo -u ubuntu tar xzf ../runner-cache/actions-runner-linux-* -C .; then
-    log_to_cloudwatch "ERROR" "Failed to extract runner archive"
+# Verify runner exists
+if [ ! -f "./run.sh" ]; then
+    log_to_cloudwatch "ERROR" "Runner not found at /opt/actions-runner"
     shutdown now
     exit 1
 fi
+log_to_cloudwatch "INFO" "Using pre-extracted GitHub runner"
 
 # Get instance type (we already have instance ID from earlier)
 INSTANCE_TYPE=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type)


### PR DESCRIPTION
## Summary
Add warm pool of pre-stopped EC2 instances to reduce GitHub runner startup time from ~90s to ~20-30s.

## Features
- Pre-create and stop EC2 instances that can be quickly started when jobs are queued
- Configurable pool sizes per instance type via JSON: `{"c8a.4xlarge":1,"c8a.2xlarge":2}`
- Scheduled maintenance (every 5 minutes) to maintain pool levels
- Instances are ephemeral - terminate after job completion, not reused
- Graceful fallback to fresh instance launch if no warm instances available

## Changes
- **main.go**: Add warm pool logic, scheduled maintenance handler, multipart MIME user-data for cloud-init
- **template.yaml**: Add WarmPoolConfig parameter, scheduled event, IAM permissions
- **user-data.sh**: Handle both pre-extracted runner and fallback to cache extraction

## How it works
1. Maintenance Lambda runs every 5 minutes to ensure pool is populated
2. When a job is queued, Lambda checks for available stopped instance in pool
3. If found: updates tags, changes shutdown behavior to TERMINATE, injects job-specific user-data, starts instance
4. If not found: launches fresh instance (original behavior)
5. After job completes, instance terminates (ephemeral)

## Test plan
- [ ] Deploy with `WARM_POOL_CONFIG={"c8a.4xlarge":1}`
- [ ] Verify instances are created and stopped by maintenance
- [ ] Queue a job and verify warm instance is activated
- [ ] Verify pool is replenished after use
- [ ] Test fallback when pool is empty