### PR TITLE
refactor: configure multi region github actions runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ EC2 key pair used for the runner. You may also specify additional runner labels:
 sam deploy \
   --parameter-overrides GitHubPATSecretName=my-github-pat \
   ExtraRunnerLabels="gpu" \
-  ImageId=ami-0123456789abcdef0 \
-  SubnetId=subnet-12345678 \
-  SecurityGroupIds=sg-12345678 \
-  KeyName=my-key
+  RunnerConfiguration='{\"us-east-2\":{\"ami\":\"0c0c88099397fccb4\",\"subnet\":\"subnet-0123456789def\",\"sg\":[\"sg-0123456789def\"],\"key\":\"terraform-2025051801\"},\"ap-southeast-5\":{\"ami\":\"0c0c88099397fccb4\",\"subnet\":\"subnet-0123456789def\",\"sg\":[\"sg-0123456789def\"],\"key\":\"terraform-2025051801\"}}'
 ```
 
 The `ExtraRunnerLabels` parameter is optional. When supplied, the labels are

--- a/main.go
+++ b/main.go
@@ -103,7 +103,9 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			}, errors.New("secret name missing")
 		}
 
-		secretOut, err := sm.GetSecretValue(context.TODO(), &secretsmanager.GetSecretValueInput{SecretId: aws.String(secretName)})
+		secretOut, err := sm.GetSecretValue(context.TODO(), &secretsmanager.GetSecretValueInput{
+			SecretId: aws.String(secretName),
+		})
 		if err != nil {
 			//nolint:gosec
 			slog.Error("failed to get secret", "secret", secretName, "error", err.Error())
@@ -179,7 +181,9 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		if instanceProfileArn == "" {
 			slog.Error("INSTANCE_PROFILE_ARN env var not set")
 
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("instance profile arn missing")
+			return events.APIGatewayProxyResponse{
+				StatusCode: http.StatusInternalServerError,
+			}, errors.New("instance profile arn missing")
 		}
 
 		tags := []types.Tag{

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
 
+		//nolint:gosec
 		slog.Info("creating runner in region", "region", region)
 
 		svc := ec2.NewFromConfig(cfg)

--- a/main.go
+++ b/main.go
@@ -70,9 +70,18 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusOK}, nil
 		}
 
+		runnerCfg := os.Getenv("RUNNER_CONFIGURATION")
+		if runnerCfg == "" {
+			slog.Error("RUNNER_CONFIGURATION env var not set")
+
+			return events.APIGatewayProxyResponse{
+				StatusCode: http.StatusInternalServerError,
+			}, errors.New("runner configuration missing")
+		}
+
 		var runnerConfig map[string]RunnerConfiguration
 
-		err := json.Unmarshal([]byte(os.Getenv("RUNNER_CONFIGURATION")), &runnerConfig)
+		err := json.Unmarshal([]byte(runnerCfg), &runnerConfig)
 		if err != nil {
 			return events.APIGatewayProxyResponse{
 				StatusCode: http.StatusInternalServerError,

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -27,6 +28,13 @@ import (
 
 //go:embed user-data.sh
 var userData string
+
+type RunnerConfiguration struct {
+	ImageID        string   `json:"ami"`
+	SubnetID       string   `json:"subnet"`
+	SecurityGroups []string `json:"sg"`
+	KeyName        string   `json:"key"`
+}
 
 func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	var githubEventHeader string
@@ -62,28 +70,36 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusOK}, nil
 		}
 
-		// parse valid regions from env var
-		validRegions := strings.Split(os.Getenv("VALID_REGIONS"), ",")
-		region := "us-east-2"
-		imageID := ""
+		var runnerConfig map[string]RunnerConfiguration
+
+		err := json.Unmarshal([]byte(os.Getenv("RUNNER_CONFIGURATION")), &runnerConfig)
+		if err != nil {
+			return events.APIGatewayProxyResponse{
+				StatusCode: http.StatusInternalServerError,
+			}, errors.New("error unmarshaling runner configuration")
+		}
+
+		region := os.Getenv("AWS_REGION")
+
 		instanceType := types.InstanceTypeC7aLarge
 		instanceTypes := instanceType.Values()
 
 		for _, label := range event.GetWorkflowJob().Labels {
-			// check AMI
-			if strings.HasPrefix(label, "ami-") {
-				imageID = label
-			}
-			// check region
-			if slices.Contains(validRegions, label) {
+			if _, ok := runnerConfig[label]; ok {
 				region = label
 			}
-			// check instance type
+
 			for i := range instanceTypes {
 				if label == string(instanceTypes[i]) {
 					instanceType = instanceTypes[i]
 				}
 			}
+		}
+
+		regionCfg, ok := runnerConfig[region]
+		if !ok {
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError},
+				fmt.Errorf("no config for region %s", region)
 		}
 
 		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
@@ -118,68 +134,6 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		extraLabels := os.Getenv("EXTRA_RUNNER_LABELS")
 		if extraLabels != "" {
 			extraLabels = "," + extraLabels
-		}
-
-		// discover subnets by tag
-		const tagParts = 2
-
-		filters := []types.Filter{}
-		subnetTags := strings.Split(os.Getenv("SUBNET_TAGS"), ",")
-
-		for _, tag := range subnetTags {
-			parts := strings.SplitN(tag, "=", tagParts)
-			if len(parts) != tagParts {
-				continue
-			}
-
-			filters = append(filters, types.Filter{
-				Name:   aws.String("tag:" + parts[0]),
-				Values: []string{parts[1]},
-			})
-		}
-
-		subnetResult, err := svc.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
-			Filters: filters,
-		})
-		if err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
-		}
-
-		if len(subnetResult.Subnets) == 0 {
-			return events.APIGatewayProxyResponse{
-					StatusCode: http.StatusInternalServerError,
-				}, fmt.Errorf("no subnets found with tags %s in region %s",
-					os.Getenv("SUBNET_TAGS"), region)
-		}
-
-		subnetID := *subnetResult.Subnets[0].SubnetId
-
-		// discover security groups by tag
-		filters = []types.Filter{}
-		sgTags := strings.Split(os.Getenv("SECURITY_GROUP_TAGS"), ",")
-
-		for _, tag := range sgTags {
-			parts := strings.SplitN(tag, "=", tagParts)
-			if len(parts) != tagParts {
-				continue
-			}
-
-			filters = append(filters, types.Filter{
-				Name:   aws.String("tag:" + parts[0]),
-				Values: []string{parts[1]},
-			})
-		}
-
-		sgResult, err := svc.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
-			Filters: filters,
-		})
-		if err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
-		}
-
-		securityGroups := []string{}
-		for _, sg := range sgResult.SecurityGroups {
-			securityGroups = append(securityGroups, *sg.GroupId)
 		}
 
 		instanceProfileArn := os.Getenv("INSTANCE_PROFILE_ARN")
@@ -233,7 +187,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 				MinCount:                          aws.Int32(1),
 				MaxCount:                          aws.Int32(1),
 				EbsOptimized:                      aws.Bool(true),
-				ImageId:                           aws.String(imageID),
+				ImageId:                           aws.String(regionCfg.ImageID),
 				InstanceInitiatedShutdownBehavior: types.ShutdownBehaviorTerminate,
 				InstanceType:                      instanceType,
 				IamInstanceProfile: &types.IamInstanceProfileSpecification{
@@ -242,12 +196,13 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 				NetworkInterfaces: []types.InstanceNetworkInterfaceSpecification{
 					{
 						AssociatePublicIpAddress: aws.Bool(true),
-						SubnetId:                 aws.String(subnetID),
+						SubnetId:                 aws.String(regionCfg.SubnetID),
 						DeleteOnTermination:      aws.Bool(true),
 						DeviceIndex:              aws.Int32(0),
-						Groups:                   securityGroups,
+						Groups:                   regionCfg.SecurityGroups,
 					},
 				},
+				KeyName:    aws.String(regionCfg.KeyName),
 				Monitoring: &types.RunInstancesMonitoringEnabled{Enabled: aws.Bool(true)},
 				TagSpecifications: []types.TagSpecification{
 					{

--- a/main.go
+++ b/main.go
@@ -117,14 +117,15 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 
 		// discover subnets by tag
 		subnetTags := strings.Split(os.Getenv("SUBNET_TAGS"), ",")
-
 		const tagParts = 2
 		filters := []types.Filter{}
+
 		for _, tag := range subnetTags {
 			parts := strings.SplitN(tag, "=", tagParts)
 			if len(parts) != tagParts {
 				continue
 			}
+
 			filters = append(filters, types.Filter{
 				Name:   aws.String("tag:" + parts[0]),
 				Values: []string{parts[1]},
@@ -146,14 +147,15 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		subnetID := *subnetResult.Subnets[0].SubnetId
 
 		// discover security groups by tag
+		filters = []types.Filter{}
 		sgTags := strings.Split(os.Getenv("SECURITY_GROUP_TAGS"), ",")
 
-		filters = []types.Filter{}
 		for _, tag := range sgTags {
 			parts := strings.SplitN(tag, "=", tagParts)
-			if len(parts) != 2 {
+			if len(parts) != tagParts {
 				continue
 			}
+
 			filters = append(filters, types.Filter{
 				Name:   aws.String("tag:" + parts[0]),
 				Values: []string{parts[1]},

--- a/main.go
+++ b/main.go
@@ -62,7 +62,34 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusOK}, nil
 		}
 
-		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-2"))
+		// parse valid regions from env var
+		validRegions := strings.Split(os.Getenv("VALID_REGIONS"), ",")
+		region := "us-east-2"
+		imageID := ""
+		instanceType := types.InstanceTypeC7aLarge
+		instanceTypes := instanceType.Values()
+
+		for _, label := range event.GetWorkflowJob().Labels {
+			// check AMI
+			if strings.HasPrefix(label, "ami-") {
+				imageID = label
+			}
+			// check region
+			for _, r := range validRegions {
+				if label == r {
+					region = label
+					break
+				}
+			}
+			// check instance type
+			for i := range instanceTypes {
+				if label == string(instanceTypes[i]) {
+					instanceType = instanceTypes[i]
+				}
+			}
+		}
+
+		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
 		if err != nil {
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
@@ -91,21 +118,58 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			extraLabels = "," + extraLabels
 		}
 
-		subnetID := os.Getenv("SUBNET_ID")
-		if subnetID == "" {
-			slog.Error("SUBNET_ID env var not set")
+		// discover subnets by tag
+		subnetTags := strings.Split(os.Getenv("SUBNET_TAGS"), ",")
 
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("subnet id missing")
+		filters := []types.Filter{}
+		for _, tag := range subnetTags {
+			parts := strings.SplitN(tag, "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			filters = append(filters, types.Filter{
+				Name:   aws.String("tag:" + parts[0]),
+				Values: []string{parts[1]},
+			})
 		}
 
-		sgIDs := os.Getenv("SECURITY_GROUP_IDS")
-		if sgIDs == "" {
-			slog.Error("SECURITY_GROUP_IDS env var not set")
-
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("security groups missing")
+		subnetResult, err := svc.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
+			Filters: filters,
+		})
+		if err != nil {
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
 
-		securityGroups := strings.Split(sgIDs, ",")
+		if len(subnetResult.Subnets) == 0 {
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError},
+				fmt.Errorf("no subnets found with tags %s in region %s", os.Getenv("SUBNET_TAGS"), region)
+		}
+
+		subnetID := *subnetResult.Subnets[0].SubnetId
+
+		// discover security groups by tag
+		sgTags := strings.Split(os.Getenv("SECURITY_GROUP_TAGS"), ",")
+
+		filters = []types.Filter{}
+		for _, tag := range sgTags {
+			parts := strings.SplitN(tag, "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			filters = append(filters, types.Filter{
+				Name:   aws.String("tag:" + parts[0]),
+				Values: []string{parts[1]},
+			})
+		}
+
+		sgResult, err := svc.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
+			Filters: filters,
+		})
+
+		securityGroups := []string{}
+		for _, sg := range sgResult.SecurityGroups {
+			securityGroups = append(securityGroups, *sg.GroupId)
+		}
 
 		keyName := os.Getenv("KEY_NAME")
 		if keyName == "" {
@@ -119,13 +183,6 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			slog.Error("INSTANCE_PROFILE_ARN env var not set")
 
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("instance profile arn missing")
-		}
-
-		imageID := os.Getenv("IMAGE_ID")
-		if imageID == "" {
-			slog.Error("IMAGE_ID env var not set")
-
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("image id missing")
 		}
 
 		tags := []types.Tag{
@@ -144,19 +201,6 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			slog.Info("not ephemeral")
 
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusOK}, nil
-		}
-
-		instanceType := types.InstanceTypeC7aLarge
-
-		instanceTypes := instanceType.Values()
-		for _, label := range event.GetWorkflowJob().Labels {
-			for i := range instanceTypes {
-				if label == string(instanceTypes[i]) {
-					instanceType = instanceTypes[i]
-
-					break
-				}
-			}
 		}
 
 		slog.Info("creating instance", "instanceType", instanceType)

--- a/main.go
+++ b/main.go
@@ -89,6 +89,9 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		}
 
 		region := os.Getenv("AWS_DEFAULT_REGION")
+		if region == "" {
+			region = os.Getenv("AWS_REGION")
+		}
 
 		instanceType := types.InstanceTypeC7aLarge
 		instanceTypes := instanceType.Values()

--- a/main.go
+++ b/main.go
@@ -83,9 +83,10 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 
 		err := json.Unmarshal([]byte(runnerCfg), &runnerConfig)
 		if err != nil {
+			slog.Error("invalid RUNNER_CONFIGURATION JSON", "error", err.Error())
 			return events.APIGatewayProxyResponse{
 				StatusCode: http.StatusInternalServerError,
-			}, errors.New("error unmarshaling runner configuration")
+			}, fmt.Errorf("RUNNER_CONFIGURATION contains invalid JSON: %w", err)
 		}
 
 		region := os.Getenv("AWS_DEFAULT_REGION")

--- a/main.go
+++ b/main.go
@@ -171,13 +171,6 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			securityGroups = append(securityGroups, *sg.GroupId)
 		}
 
-		keyName := os.Getenv("KEY_NAME")
-		if keyName == "" {
-			slog.Error("KEY_NAME env var not set")
-
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("key name missing")
-		}
-
 		instanceProfileArn := os.Getenv("INSTANCE_PROFILE_ARN")
 		if instanceProfileArn == "" {
 			slog.Error("INSTANCE_PROFILE_ARN env var not set")
@@ -238,7 +231,6 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 						Groups:                   securityGroups,
 					},
 				},
-				KeyName:    aws.String(keyName),
 				Monitoring: &types.RunInstancesMonitoringEnabled{Enabled: aws.Bool(true)},
 				TagSpecifications: []types.TagSpecification{
 					{

--- a/main.go
+++ b/main.go
@@ -83,7 +83,8 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 
 		err := json.Unmarshal([]byte(runnerCfg), &runnerConfig)
 		if err != nil {
-			slog.Error("invalid RUNNER_CONFIGURATION JSON", "error", err.Error())
+			slog.Error("invalid RUNNER_CONFIGURATION JSON", "error", err.Error()) //nolint:gosec
+
 			return events.APIGatewayProxyResponse{
 				StatusCode: http.StatusInternalServerError,
 			}, fmt.Errorf("RUNNER_CONFIGURATION contains invalid JSON: %w", err)

--- a/main.go
+++ b/main.go
@@ -146,8 +146,10 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		}
 
 		if len(subnetResult.Subnets) == 0 {
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError},
-				fmt.Errorf("no subnets found with tags %s in region %s", os.Getenv("SUBNET_TAGS"), region)
+			return events.APIGatewayProxyResponse{
+					StatusCode: http.StatusInternalServerError,
+				}, fmt.Errorf("no subnets found with tags %s in region %s",
+					os.Getenv("SUBNET_TAGS"), region)
 		}
 
 		subnetID := *subnetResult.Subnets[0].SubnetId
@@ -171,6 +173,9 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		sgResult, err := svc.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
 			Filters: filters,
 		})
+		if err != nil {
+			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
+		}
 
 		securityGroups := []string{}
 		for _, sg := range sgResult.SecurityGroups {
@@ -212,8 +217,12 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		}
 
 		var buf bytes.Buffer
-		if err := tpl.Execute(&buf, map[string]string{"GitHubPAT": pat, "ExtraLabels": extraLabels}); err != nil {
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
+
+		err = tpl.Execute(&buf, map[string]string{"GitHubPAT": pat, "ExtraLabels": extraLabels})
+		if err != nil {
+			return events.APIGatewayProxyResponse{
+				StatusCode: http.StatusInternalServerError,
+			}, fmt.Errorf("failed to execute template: %w", err)
 		}
 
 		finalUserData := buf.String()

--- a/main.go
+++ b/main.go
@@ -75,11 +75,8 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 				imageID = label
 			}
 			// check region
-			for _, r := range validRegions {
-				if label == r {
-					region = label
-					break
-				}
+			if slices.Contains(validRegions, label) {
+				region = label
 			}
 			// check instance type
 			for i := range instanceTypes {
@@ -121,10 +118,11 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		// discover subnets by tag
 		subnetTags := strings.Split(os.Getenv("SUBNET_TAGS"), ",")
 
+		const tagParts = 2
 		filters := []types.Filter{}
 		for _, tag := range subnetTags {
-			parts := strings.SplitN(tag, "=", 2)
-			if len(parts) != 2 {
+			parts := strings.SplitN(tag, "=", tagParts)
+			if len(parts) != tagParts {
 				continue
 			}
 			filters = append(filters, types.Filter{
@@ -152,7 +150,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 
 		filters = []types.Filter{}
 		for _, tag := range sgTags {
-			parts := strings.SplitN(tag, "=", 2)
+			parts := strings.SplitN(tag, "=", tagParts)
 			if len(parts) != 2 {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -107,6 +107,8 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 		}
 
+		slog.Info("creating runner in region", "region", region)
+
 		svc := ec2.NewFromConfig(cfg)
 		sm := secretsmanager.NewFromConfig(cfg)
 
@@ -219,6 +221,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			},
 		)
 		if err != nil {
+			//nolint:gosec
 			slog.Error(err.Error())
 
 			return events.APIGatewayProxyResponse{
@@ -236,6 +239,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			}, nil
 		}
 
+		//nolint:gosec
 		slog.Info("instance created", "instanceID", output.Instances[0].InstanceId)
 
 		return events.APIGatewayProxyResponse{

--- a/main.go
+++ b/main.go
@@ -92,6 +92,8 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			for i := range instanceTypes {
 				if label == string(instanceTypes[i]) {
 					instanceType = instanceTypes[i]
+
+					break
 				}
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 			}, errors.New("error unmarshaling runner configuration")
 		}
 
-		region := os.Getenv("AWS_REGION")
+		region := os.Getenv("AWS_DEFAULT_REGION")
 
 		instanceType := types.InstanceTypeC7aLarge
 		instanceTypes := instanceType.Values()

--- a/main.go
+++ b/main.go
@@ -98,11 +98,14 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		if secretName == "" {
 			slog.Error("GITHUB_PAT_SECRET_NAME env var not set")
 
-			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, errors.New("secret name missing")
+			return events.APIGatewayProxyResponse{
+				StatusCode: http.StatusInternalServerError,
+			}, errors.New("secret name missing")
 		}
 
 		secretOut, err := sm.GetSecretValue(context.TODO(), &secretsmanager.GetSecretValueInput{SecretId: aws.String(secretName)})
 		if err != nil {
+			//nolint:gosec
 			slog.Error("failed to get secret", "secret", secretName, "error", err.Error())
 
 			return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
@@ -116,9 +119,10 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		}
 
 		// discover subnets by tag
-		subnetTags := strings.Split(os.Getenv("SUBNET_TAGS"), ",")
 		const tagParts = 2
+
 		filters := []types.Filter{}
+		subnetTags := strings.Split(os.Getenv("SUBNET_TAGS"), ",")
 
 		for _, tag := range subnetTags {
 			parts := strings.SplitN(tag, "=", tagParts)

--- a/samconfig.example.yaml
+++ b/samconfig.example.yaml
@@ -10,10 +10,8 @@ dev:
       parameter_overrides:
         - GitHubPATSecretName=github-runner-autoscaler-pat
         - ExtraRunnerLabels=dev
-        - ImageId=ami-0c0c88099397fccb4
-        - SubnetId=subnet-0123456789def
-        - SecurityGroupIds=sg-0123456789def
-        - KeyName=terraform-2025051802
+        - SubnetTag=github-runner=true
+        - SecurityGroupTags=github-runner=true
 prod:
   deploy:
     parameters:
@@ -25,7 +23,5 @@ prod:
       parameter_overrides:
         - GitHubPATSecretName=github-runner-autoscaler-pat
         - ExtraRunnerLabels=prod
-        - ImageId=ami-0c0c88099397fccb4
-        - SubnetId=subnet-0123456789def
-        - SecurityGroupIds=sg-0123456789def
-        - KeyName=terraform-2025051801
+        - SubnetTag=github-runner=true
+        - SecurityGroupTags=github-runner=true

--- a/samconfig.example.yaml
+++ b/samconfig.example.yaml
@@ -13,13 +13,13 @@ dev:
         - >-
           RunnerConfiguration={
             "us-east-2":{
-              "ami":"0c0c88099397fccb4",
+              "ami":"ami-0c0c88099397fccb4",
               "subnet":"subnet-0123456789def",
               "sg":["sg-0123456789def"],
               "key":"terraform-2025051801"
             },
             "ap-southeast-5":{
-              "ami":"0c0c88099397fccb4",
+              "ami":"ami-0c0c88099397fccb4",
               "subnet":"subnet-0123456789def",
               "sg":["sg-0123456789def"],
               "key":"terraform-2025051801"
@@ -39,13 +39,13 @@ prod:
         - >-
           RunnerConfiguration={
             "us-east-2":{
-              "ami":"0c0c88099397fccb4",
+              "ami":"ami-0c0c88099397fccb4",
               "subnet":"subnet-0123456789def",
               "sg":["sg-0123456789def"],
               "key":"terraform-2025051801"
             },
             "ap-southeast-5":{
-              "ami":"0c0c88099397fccb4",
+              "ami":"ami-0c0c88099397fccb4",
               "subnet":"subnet-0123456789def",
               "sg":["sg-0123456789def"],
               "key":"terraform-2025051801"

--- a/samconfig.example.yaml
+++ b/samconfig.example.yaml
@@ -10,8 +10,21 @@ dev:
       parameter_overrides:
         - GitHubPATSecretName=github-runner-autoscaler-pat
         - ExtraRunnerLabels=dev
-        - SubnetTag=github-runner=true
-        - SecurityGroupTags=github-runner=true
+        - >-
+          RegionConfig={
+            "us-east-2":{
+              "ami":"0c0c88099397fccb4",
+              "subnet":"subnet-0123456789def",
+              "sg":["sg-0123456789def"],
+              "key":"terraform-2025051801"
+            },
+            "ap-southeast-5":{
+              "ami":"0c0c88099397fccb4",
+              "subnet":"subnet-0123456789def",
+              "sg":["sg-0123456789def"],
+              "key":"terraform-2025051801"
+            }
+          }
 prod:
   deploy:
     parameters:
@@ -23,5 +36,18 @@ prod:
       parameter_overrides:
         - GitHubPATSecretName=github-runner-autoscaler-pat
         - ExtraRunnerLabels=prod
-        - SubnetTag=github-runner=true
-        - SecurityGroupTags=github-runner=true
+        - >-
+          RegionConfig={
+            "us-east-2":{
+              "ami":"0c0c88099397fccb4",
+              "subnet":"subnet-0123456789def",
+              "sg":["sg-0123456789def"],
+              "key":"terraform-2025051801"
+            },
+            "ap-southeast-5":{
+              "ami":"0c0c88099397fccb4",
+              "subnet":"subnet-0123456789def",
+              "sg":["sg-0123456789def"],
+              "key":"terraform-2025051801"
+            }
+          }

--- a/samconfig.example.yaml
+++ b/samconfig.example.yaml
@@ -11,7 +11,7 @@ dev:
         - GitHubPATSecretName=github-runner-autoscaler-pat
         - ExtraRunnerLabels=dev
         - >-
-          RegionConfig={
+          RunnerConfiguration={
             "us-east-2":{
               "ami":"0c0c88099397fccb4",
               "subnet":"subnet-0123456789def",
@@ -37,7 +37,7 @@ prod:
         - GitHubPATSecretName=github-runner-autoscaler-pat
         - ExtraRunnerLabels=prod
         - >-
-          RegionConfig={
+          RunnerConfiguration={
             "us-east-2":{
               "ami":"0c0c88099397fccb4",
               "subnet":"subnet-0123456789def",

--- a/template.yaml
+++ b/template.yaml
@@ -9,18 +9,15 @@ Parameters:
     Type: String
     Default: ""
     Description: Additional comma separated labels for the runner
-  ImageId:
-    Type: String
-    Description: AMI ID for the runner instances
-  SubnetId:
-    Type: String
-    Description: Subnet ID for the runner instances
-  SecurityGroupIds:
-    Type: String
-    Description: Comma separated security group IDs for the runner
-  KeyName:
-    Type: String
-    Description: EC2 key pair name for the runner
+  ValidRegions:
+    Type: CommaDelimitedList
+    Description: List of valid AWS regions for runner deployment.
+  SubnetTags:
+    Type: CommaDelimitedList
+    Description: Comma separated list of tag key-value pairs to discover subnets
+  SecurityGroupTags:
+    Type: CommaDelimitedList
+    Description: Comma separated list of tag key-value pairs to discover security groups
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -81,10 +78,9 @@ Resources:
         Variables:
           GITHUB_PAT_SECRET_NAME: !Ref GitHubPATSecretName
           EXTRA_RUNNER_LABELS: !Ref ExtraRunnerLabels
-          IMAGE_ID: !Ref ImageId
-          SUBNET_ID: !Ref SubnetId
-          SECURITY_GROUP_IDS: !Ref SecurityGroupIds
-          KEY_NAME: !Ref KeyName
+          SUBNET_TAGS: !Join [",", !Ref SubnetTags]
+          SECURITY_GROUP_TAGS: !Join [",", !Ref SecurityGroupTags]
+          VALID_REGIONS: !Join [",", !Ref ValidRegions]
           INSTANCE_PROFILE_ARN: !GetAtt RunnerInstanceProfile.Arn
       Policies:
         - Statement:

--- a/template.yaml
+++ b/template.yaml
@@ -88,7 +88,7 @@ Resources:
               Effect: Allow
               Action:
                 - secretsmanager:GetSecretValue
-              Resource: !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${GitHubPATSecretName}*
+              Resource: !Sub arn:${AWS::Partition}:secretsmanager:*:${AWS::AccountId}:secret:${GitHubPATSecretName}*
     Metadata:
       BuildMethod: makefile
 

--- a/template.yaml
+++ b/template.yaml
@@ -44,7 +44,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                   - logs:DescribeLogStreams
-                Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/ec2/github-runner:*'
+                Resource: !Sub 'arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:/aws/ec2/github-runner:*'
 
   RunnerInstanceProfile:
     Type: AWS::IAM::InstanceProfile

--- a/template.yaml
+++ b/template.yaml
@@ -9,15 +9,9 @@ Parameters:
     Type: String
     Default: ""
     Description: Additional comma separated labels for the runner
-  ValidRegions:
-    Type: CommaDelimitedList
-    Description: List of valid AWS regions for runner deployment.
-  SubnetTags:
-    Type: CommaDelimitedList
-    Description: Comma separated list of tag key-value pairs to discover subnets
-  SecurityGroupTags:
-    Type: CommaDelimitedList
-    Description: Comma separated list of tag key-value pairs to discover security groups
+  RunnerConfiguration:
+    Type: String
+    Description: JSON string defining per-region runner settings (AMI, subnet, security group, SSH key).
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -78,9 +72,7 @@ Resources:
         Variables:
           GITHUB_PAT_SECRET_NAME: !Ref GitHubPATSecretName
           EXTRA_RUNNER_LABELS: !Ref ExtraRunnerLabels
-          SUBNET_TAGS: !Join [",", !Ref SubnetTags]
-          SECURITY_GROUP_TAGS: !Join [",", !Ref SecurityGroupTags]
-          VALID_REGIONS: !Join [",", !Ref ValidRegions]
+          RUNNER_CONFIGURATION: !Ref RunnerConfiguration
           INSTANCE_PROFILE_ARN: !GetAtt RunnerInstanceProfile.Arn
       Policies:
         - Statement:

--- a/user-data.sh
+++ b/user-data.sh
@@ -9,7 +9,14 @@ INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.2
 # CloudWatch logging setup
 LOG_GROUP="/aws/ec2/github-runner"
 LOG_STREAM="runner-${INSTANCE_ID}-$(date +%Y%m%d-%H%M%S)"
+
+# Get region information
 REGION=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
+if [ -z "${REGION}" ]; then
+    echo "Failed to determine AWS region from instance metadata; REGION is empty." >&2
+    shutdown now
+    exit 1
+fi
 
 # Configure AWS CLI default region
 aws configure set default.region "${REGION}"

--- a/user-data.sh
+++ b/user-data.sh
@@ -9,10 +9,10 @@ INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.2
 # CloudWatch logging setup
 LOG_GROUP="/aws/ec2/github-runner"
 LOG_STREAM="runner-${INSTANCE_ID}-$(date +%Y%m%d-%H%M%S)"
-REGION="us-east-2"
+REGION=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
 
 # Configure AWS CLI default region
-aws configure set default.region ${REGION}
+aws configure set default.region "${REGION}"
 
 # Function to log to CloudWatch
 log_to_cloudwatch() {
@@ -74,6 +74,9 @@ fi
 # Get instance type (we already have instance ID from earlier)
 INSTANCE_TYPE=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type)
 
+# Get AMI ID
+AMI_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/ami-id)
+
 log_to_cloudwatch "INFO" "Instance: ${INSTANCE_ID}, Type: ${INSTANCE_TYPE}"
 
 # Function to get GitHub registration token with retry
@@ -125,7 +128,7 @@ while [ $config_attempt -le $max_config_attempts ]; do
         --token "$GITHUB_TOKEN" \
         --disableupdate \
         --ephemeral \
-        --labels "${INSTANCE_TYPE},ephemeral,X64{{.ExtraLabels}}" \
+        --labels "${INSTANCE_TYPE},ephemeral,X64{{.ExtraLabels}},${REGION},${AMI_ID}" \
         --unattended \
         --name "ephemeral-${INSTANCE_ID}" \
         --work _work; then

--- a/user-data.sh
+++ b/user-data.sh
@@ -74,9 +74,6 @@ fi
 # Get instance type (we already have instance ID from earlier)
 INSTANCE_TYPE=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type)
 
-# Get AMI ID
-AMI_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/ami-id)
-
 log_to_cloudwatch "INFO" "Instance: ${INSTANCE_ID}, Type: ${INSTANCE_TYPE}"
 
 # Function to get GitHub registration token with retry
@@ -128,7 +125,7 @@ while [ $config_attempt -le $max_config_attempts ]; do
         --token "$GITHUB_TOKEN" \
         --disableupdate \
         --ephemeral \
-        --labels "${INSTANCE_TYPE},ephemeral,X64{{.ExtraLabels}},${REGION},${AMI_ID}" \
+        --labels "${INSTANCE_TYPE},ephemeral,X64{{.ExtraLabels}},${REGION}" \
         --unattended \
         --name "ephemeral-${INSTANCE_ID}" \
         --work _work; then


### PR DESCRIPTION
**Multi-Region GitHub Actions Runner Support**
Our GitHub Actions runners previously ran exclusively in us-east-2. As our infrastructure has since largely migrated to the Malaysia region (ap-southeast-5), workflows such as AMI builds and VORStream deployments were incurring unnecessary latency due to cross-region communication.

This PR updates the runner autoscaler Lambda to dynamically select the region in which a runner is deployed, based on labels provided in the GitHub webhook payload. By default, runners are deployed in the same region they currently live in. If a label matching a configured region is present in the webhook payload, that region is used instead.

**Label Changes**
Runner labels now support an optional region specifier:
**Before**
[self-hosted, ephemeral, vor-stream-sdlc, c8a.medium]

**After**
[self-hosted, ephemeral, vor-stream-sdlc, c8a.medium, ap-southeast-5]

**Configuration Changes**
The four separate template parameters (ImageId, SubnetId, SecurityGroupIds, KeyName) have been consolidated into a single RunnerConfiguration parameter, which accepts a JSON map(passed as a string) of per-region resource configuration. This can be configured in samconfig.yaml under parameter_overrides as follows:
```
parameter_overrides:
        - >-
          RunnerConfiguration='{
            "us-east-2":{
              "ami":"ami-046248306c4d3cedf",
              "subnet":"subnet-0eb6da43c6f0ef528",
              "sg":["sg-0f185b577cb2b2802"],
              "key":"terraform-20220125192645402400000001"
            },
            "ap-southeast-5":{
              "ami":"ami-06543510d0a069dcc",
              "subnet":"subnet-041f9408ed87e3b5a",
              "sg":["sg-0ed35ed8140ff7c60"],
              "key":"terraform-20251216090622674300000001"
            }
          }'
```

**Minor changes**
- Expanded RunInstances policy and RunnerInstanceRole permissions to support all regions (previously restricted to us-east-2).
- Ignored the gosec error G706 since it is unlikely for an attacker to be able to control the input to the logs.